### PR TITLE
Add state overrides to callBundle rpc

### DIFF
--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -2399,6 +2399,7 @@ type CallBundleArgs struct {
 	BaseFee                *big.Int              `json:"baseFee"`
 	SimulationLogs         bool                  `json:"simulationLogs"`
 	CreateAccessList       bool                  `json:"createAccessList"`
+	StateOverrides         *StateOverride		  `json:"stateOverrides"`
 }
 
 // CallBundle will simulate a bundle of transactions at the top of a given block
@@ -2433,6 +2434,9 @@ func (s *BundleAPI) CallBundle(ctx context.Context, args CallBundleArgs) (map[st
 	timeout := time.Millisecond * time.Duration(timeoutMilliSeconds)
 	state, parent, err := s.b.StateAndHeaderByNumberOrHash(ctx, args.StateBlockNumberOrHash)
 	if state == nil || err != nil {
+		return nil, err
+	}
+	if err := args.StateOverrides.Apply(state); err != nil {
 		return nil, err
 	}
 	blockNumber := big.NewInt(int64(args.BlockNumber))

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -1285,7 +1285,7 @@ func (w *worker) fillTransactions(interrupt *int32, env *environment) error {
 	}
 	if w.flashbots.isMegabundleWorker {
 		megabundle, err := w.eth.TxPool().GetMegabundle(w.flashbots.relayAddr, env.header.Number, env.header.Time)
-		log.Info("Starting to process a Megabundle", "relay", w.flashbots.relayAddr, "megabundle", megabundle, "error", err)
+		log.Debug("Starting to process a Megabundle", "relay", w.flashbots.relayAddr, "megabundle", megabundle, "error", err)
 		if err != nil {
 			return err // no valid megabundle for this relay, nothing to do
 		}


### PR DESCRIPTION
Hi I have added the stateoverride option to the callBundle rpc. Could be handy in case you want to fiddle with state while simulating transactions. It does compile but I did not test it yet, any feedback is welcome!